### PR TITLE
Feat: Simplifica o processo de inicialização do ambiente de desenvolvimento

### DIFF
--- a/docs/ambiente.md
+++ b/docs/ambiente.md
@@ -24,13 +24,23 @@ Para mais informações, consulte a [documentação oficial do NVM](https://gith
 
 ---
 
-Para preparar o ambiente execute:
+Para preparar o ambiente, o primeiro passo é criar o arquivo de variáveis de ambiente `.env`. O projeto inclui um arquivo de exemplo chamado `.env-example` que deve ser usado como base.
+
+Você pode criar o seu arquivo `.env` copiando o exemplo.
+
+**No Linux ou macOS:**
 
 ```sh
-./tools/scripts/setup.sh
+cp .env-example .env
 ```
 
-Caso tenha dado tudo certo e você esteja com node e pnpm instalado com docker executado, está tudo pronto!
+**No Windows (PowerShell):**
+
+```powershell
+Copy-Item .env-example .env
+```
+
+Após criar o arquivo `.env`, você está pronto para iniciar o ambiente.
 
 Para começar execute:
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "nxCloudId": "66ed082b0f768c3e7a77e1a5",
   "scripts": {
-    "dev": "nx run-many -t serve --projects=server,devmx --configuration=development",
+    "dev": "pnpm docker:compose:only:mongo && nx run-many -t serve --projects=server,devmx --configuration=development",
     "dev:server": "nx serve server",
     "build:server": "pnpm nx build server --verbose",
     "dev:mx": "nx serve devmx",


### PR DESCRIPTION
# Qual o problema que esta mudança resolve?
Atualmente, o processo para iniciar o ambiente de desenvolvimento é manual e propenso a erros. O desenvolvedor precisa executar dois comandos em terminais separados e na ordem correta:

docker compose mongodb up -d (ou pnpm docker:compose:only:mongo) para iniciar o banco de dados.

pnpm dev para iniciar o frontend e o backend (via Nx).

Essa abordagem pode levar a erros se o banco de dados não for iniciado antes das aplicações, além de ser um passo extra que prejudica a produtividade e a Developer Experience (DX).

## Qual a solução proposta?
Para resolver isso, o script dev no arquivo package.json foi modificado para automatizar a inicialização do contêiner do MongoDB junto com as aplicações.

Com a alteração, ao executar pnpm dev:

O contêiner do banco de dados é iniciado primeiro.

Em seguida, as aplicações (frontend e backend via Nx) são executadas.

Isso unifica todo o processo em um único comando, tornando o setup mais rápido, simples e à prova de erros para todos os sistemas operacionais (Linux, Windows, macOS).

## Alternativas consideradas
Foi considerado manter os comandos separados e apenas melhorar a documentação, mas a automação do processo através do package.json se mostrou uma solução muito mais robusta e alinhada com as boas práticas de DX.

## Contexto da Implementação (package.json)
A mudança foi implementada no bloco scripts do package.json da seguinte forma:
`"dev": "pnpm docker:compose:only:mongo && nx run-many -t serve --projects=server,devmx --configuration=development",`
Isso garante que a experiência de desenvolvimento seja mais fluida para todos os contribuidores do projeto.